### PR TITLE
fix: made options to withExistingTokenFlow optional (#320)

### DIFF
--- a/.changeset/violet-timers-sin.md
+++ b/.changeset/violet-timers-sin.md
@@ -1,0 +1,5 @@
+---
+"@commercetools/sdk-client-v2": patch
+---
+
+fix: make options for `withExistingTokenFlow` method optional

--- a/packages/sdk-client/src/client-builder/ClientBuilder.ts
+++ b/packages/sdk-client/src/client-builder/ClientBuilder.ts
@@ -145,7 +145,7 @@ export default class ClientBuilder {
 
   withExistingTokenFlow(
     authorization: string,
-    options: ExistingTokenMiddlewareOptions
+    options?: ExistingTokenMiddlewareOptions
   ): ClientBuilder {
     return this.withAuthMiddleware(
       createAuthMiddlewareWithExistingToken(authorization, {


### PR DESCRIPTION
* fix: made options to withExistingTokenFlow optional

* fix(client-builder): make parameter optional

- [x] make the second parameter of the `withExistingTokenFlow()` method optional.

Co-authored-by: Ajima Chukwuemeka <32770340+ajimae@users.noreply.github.com>